### PR TITLE
fix: richtext use xss to prevent error on import of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"@fontsource/poppins": "^4.5.10",
 		"copy-to-clipboard": "^3.3.3",
 		"ctix": "^1.8.1",
-		"dompurify": "^2.4.3",
-		"moment": "^2.29.4"
+		"moment": "^2.29.4",
+		"xss": "^1.0.14"
 	}
 }

--- a/src/components/Atoms/Richtext/Richtext.stories.tsx
+++ b/src/components/Atoms/Richtext/Richtext.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Richtext as Component, RichtextSizeMap } from './Richtext';
+import { Richtext as Component, RichtextSizeMap, defaultAllowedTags } from './Richtext';
 
 export default {
 	title: 'Components/Atoms/Richtext',
@@ -21,7 +21,7 @@ export const SimpleText = Template.bind({});
 SimpleText.args = {
 	size: 'L',
 	children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-	allowedTags: ['p', 'a'],
+	allowedTags: defaultAllowedTags,
 };
 
 export const Richtext = Template.bind({});
@@ -29,12 +29,12 @@ Richtext.args = {
 	size: 'L',
 	children:
 		'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam scelerisque mauris eu diam lobortis, eget venenatis lacus viverra.</p><p>Maecenas fringilla velit vel justo pretium, in sollicitudin <a href="http://maecenasfringilla.com">Maecenasfringilla.com</a> nisi condimentum. Proin tincidunt lacus at libero venenatis, a blandit lectus euismod.</p><p><a href="#velitvel">#velitvel</a> <a href="#justopretium">#justopretium</a></p>',
-	allowedTags: ['p', 'a'],
+	allowedTags: defaultAllowedTags,
 };
 
 export const ForbiddenTags = Template.bind({});
 ForbiddenTags.args = {
 	size: 'L',
 	children: '<script>alert("Hello World")</script> and some other Tags <b>bold</b>, <small>small</small>, <i>italic</i>',
-	allowedTags: ['p', 'a'],
+	allowedTags: defaultAllowedTags,
 };


### PR DESCRIPTION
Hier habe ich dompurify durch xss ersetzt. Dies sollte für die Fehler für den Richtext bei Gebrauch entfernen. Was meinst?